### PR TITLE
fix online status text being wrong color due to lighting

### DIFF
--- a/src/main/java/com/sintinium/oauth/gui/TextWidget.java
+++ b/src/main/java/com/sintinium/oauth/gui/TextWidget.java
@@ -2,6 +2,8 @@ package com.sintinium.oauth.gui;
 
 import net.minecraft.client.gui.GuiScreen;
 
+import org.lwjgl.opengl.GL11;
+
 public class TextWidget {
 
     private final int x;
@@ -24,6 +26,9 @@ public class TextWidget {
     }
 
     public void draw(GuiScreen screen) {
+        GL11.glPushAttrib(GL11.GL_LIGHTING);
+        GL11.glDisable(GL11.GL_LIGHTING);
         screen.drawString(screen.mc.fontRenderer, text, x, y, color);
+        GL11.glPopAttrib();
     }
 }


### PR DESCRIPTION
The online status text in the top left of the multiplayer menu wasn't disabling shadow.
This already caused it to be discolored when hovering over the fml compat status or player list indicator of servers in the server list since that popup element enables lighting.

https://github.com/user-attachments/assets/31c84b3c-ab2e-444b-ab5b-6bad23378b5b

With GTNH 2.7.0, the text was now always the wrong color so it's a lot more noticable
This fixes that by just pushing, setting, and popping lighting mode flag. 
Tested in full pack (2.7 release)